### PR TITLE
Fix typo in walkthrough doc

### DIFF
--- a/stateful-functions-docs/docs/getting_started/walkthrough.rst
+++ b/stateful-functions-docs/docs/getting_started/walkthrough.rst
@@ -186,7 +186,7 @@ Then, send some messages to the topic "names", and observe what comes out of "gr
 
 .. code-block:: bash
 
-    $ KAFKA=$(docker ps -f "name=stateful-functions-greeter-example-broker_1" --format "{{.ID}}")
+    $ KAFKA=$(docker ps -f "name=stateful-functions-greeter-example_kafka-broker_1" --format "{{.ID}}")
     $ docker exec -it $KAFKA kafka-console-consumer.sh \
         --bootstrap-server localhost:9092 \
         --topic greetings


### PR DESCRIPTION
It is a typo,  the description in https://github.com/ververica/stateful-functions/blob/master/README.md is right.