### PR TITLE
[readme][docs] Use docker-compose exec in the docs and the READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,17 +134,15 @@ This example contains a very basic stateful function with a Kafka ingress and a 
 To see the example in action, send some messages to the topic `names`, and see what comes out out of the topic `greetings`:
 
 ```
-KAFKA=$(docker ps -f "name=stateful-functions-greeter-example_kafka-broker_1" --format "{{.ID}}") ; \
-docker exec -it $KAFKA kafka-console-producer.sh \
+docker-compose exec kafka-broker kafka-console-producer.sh \
      --broker-list localhost:9092 \
      --topic names
 ```
 
 ```
-KAFKA=$(docker ps -f "name=stateful-functions-greeter-example_kafka-broker_1" --format "{{.ID}}") ; \
-docker exec -it $KAFKA kafka-console-consumer.sh \
+docker-compose exec kafka-broker kafka-console-consumer.sh \
      --bootstrap-server localhost:9092 \
-     --topic greetings
+     --topic greetings --from-beginning
 ```
 
 ### <a name="project-setup"></a>Project setup

--- a/stateful-functions-docs/docs/getting_started/walkthrough.rst
+++ b/stateful-functions-docs/docs/getting_started/walkthrough.rst
@@ -179,15 +179,13 @@ Then, send some messages to the topic "names", and observe what comes out of "gr
 
 .. code-block:: bash
 
-    $ KAFKA=$(docker ps -f "name=stateful-functions-greeter-example_kafka-broker_1" --format "{{.ID}}")
-    $ docker exec -it $KAFKA kafka-console-producer.sh \
+    $ docker-compose exec kafka-broker kafka-console-producer.sh \
         --broker-list localhost:9092 \
         --topic names
 
 .. code-block:: bash
 
-    $ KAFKA=$(docker ps -f "name=stateful-functions-greeter-example_kafka-broker_1" --format "{{.ID}}")
-    $ docker exec -it $KAFKA kafka-console-consumer.sh \
+    $ docker-compose exec kafka-broker kafka-console-consumer.sh \
         --bootstrap-server localhost:9092 \
         --topic greetings
 

--- a/stateful-functions-examples/stateful-functions-greeter-example/README.md
+++ b/stateful-functions-examples/stateful-functions-greeter-example/README.md
@@ -18,15 +18,13 @@ Then, to see the example in actions, send some messages to the topic `names`, an
 out of the topic `greetings`:
 
 ```
-KAFKA=$(docker ps -f "name=stateful-functions-greeter-example_kafka-broker_1" --format "{{.ID}}") ; \
-docker exec -it $KAFKA kafka-console-producer.sh \
+docker-compose exec kafka-broker kafka-console-producer.sh \
      --broker-list localhost:9092 \
      --topic names
 ```
 
 ```
-KAFKA=$(docker ps -f "name=stateful-functions-greeter-example_kafka-broker_1" --format "{{.ID}}") ; \
-docker exec -it $KAFKA kafka-console-consumer.sh \
+docker-compose exec kafka-broker kafka-console-consumer.sh \
      --bootstrap-server localhost:9092 \
-     --topic greetings
+     --topic greetings --from-beginning
 ```


### PR DESCRIPTION
This PR address issue #13, by changing the docs and the README files to use `docker-compose exec <service name>` instead capturing the Docker filter output.

see: https://docs.docker.com/compose/reference/exec/ 

This approach was verified on OSX and Ubuntu 19.04 with Docker 19.03.2