### PR TITLE
Add maven-enforcer-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -158,6 +158,27 @@ limitations under the License.
                     </execution>
                 </executions>
             </plugin>
+
+            <!-- Dependency Enforcer -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>3.0.0-M2</version>
+                <executions>
+                    <execution>
+                        <id>enforce</id>
+                        <configuration>
+                            <rules>
+                                <dependencyConvergence/>
+                            </rules>
+                        </configuration>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            
         </plugins>
     </build>
 </project>

--- a/stateful-functions-flink/stateful-functions-flink-distribution/pom.xml
+++ b/stateful-functions-flink/stateful-functions-flink-distribution/pom.xml
@@ -33,7 +33,7 @@ limitations under the License.
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
-            <version>1.7.7</version>
+            <version>1.7.15</version>
         </dependency>
         <dependency>
             <groupId>log4j</groupId>

--- a/stateful-functions-flink/stateful-functions-flink-harness/pom.xml
+++ b/stateful-functions-flink/stateful-functions-flink-harness/pom.xml
@@ -46,6 +46,12 @@ limitations under the License.
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-runtime_2.11</artifactId>
             <version>${flink.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 

--- a/stateful-functions-flink/stateful-functions-flink-io-bundle/pom.xml
+++ b/stateful-functions-flink/stateful-functions-flink-io-bundle/pom.xml
@@ -71,6 +71,16 @@ limitations under the License.
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-connector-kafka_2.11</artifactId>
             <version>${flink.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.xerial.snappy</groupId>
+                    <artifactId>snappy-java</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
             <scope>compile</scope>
         </dependency>
 

--- a/stateful-functions-flink/stateful-functions-flink-io/pom.xml
+++ b/stateful-functions-flink/stateful-functions-flink-io/pom.xml
@@ -38,8 +38,13 @@ limitations under the License.
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-streaming-java_2.11</artifactId>
             <version>${flink.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
-
 
 </project>

--- a/stateful-functions-kafka-io/pom.xml
+++ b/stateful-functions-kafka-io/pom.xml
@@ -52,6 +52,10 @@ limitations under the License.
                     <groupId>org.xerial.snappy</groupId>
                     <artifactId>snappy-java</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
     </dependencies>

--- a/stateful-functions-sdk/pom.xml
+++ b/stateful-functions-sdk/pom.xml
@@ -27,7 +27,7 @@ limitations under the License.
     <artifactId>stateful-functions-sdk</artifactId>
 
     <properties>
-        <jsr305.version>3.0.2</jsr305.version>
+        <jsr305.version>1.3.9</jsr305.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
This PR adds the [maven-enforcer-plugin](https://maven.apache.org/enforcer/maven-enforcer-plugin/) to keep dependency versioned synced.