### PR TITLE
Replace MailboxExecutor missing method

### DIFF
--- a/stateful-functions-flink/stateful-functions-flink-core/src/main/java/com/ververica/statefun/flink/core/common/MailboxExecutorFacade.java
+++ b/stateful-functions-flink/stateful-functions-flink-core/src/main/java/com/ververica/statefun/flink/core/common/MailboxExecutorFacade.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019 Ververica GmbH.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ververica.statefun.flink.core.common;
+
+import java.util.Objects;
+import java.util.concurrent.Executor;
+import org.apache.flink.streaming.api.operators.MailboxExecutor;
+
+public final class MailboxExecutorFacade implements Executor {
+  private final MailboxExecutor executor;
+  private final String name;
+
+  public MailboxExecutorFacade(MailboxExecutor executor, String name) {
+    this.executor = Objects.requireNonNull(executor);
+    this.name = Objects.requireNonNull(name);
+  }
+
+  @Override
+  public void execute(Runnable command) {
+    executor.execute(command::run, name);
+  }
+}

--- a/stateful-functions-flink/stateful-functions-flink-core/src/main/java/com/ververica/statefun/flink/core/feedback/FeedbackKey.java
+++ b/stateful-functions-flink/stateful-functions-flink-core/src/main/java/com/ververica/statefun/flink/core/feedback/FeedbackKey.java
@@ -44,7 +44,7 @@ public final class FeedbackKey<V> implements Serializable {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    FeedbackKey that = (FeedbackKey) o;
+    FeedbackKey<?> that = (FeedbackKey<?>) o;
     return invocationId == that.invocationId && Objects.equals(pipelineName, that.pipelineName);
   }
 

--- a/stateful-functions-flink/stateful-functions-flink-core/src/main/java/com/ververica/statefun/flink/core/feedback/FeedbackUnionOperator.java
+++ b/stateful-functions-flink/stateful-functions-flink-core/src/main/java/com/ververica/statefun/flink/core/feedback/FeedbackUnionOperator.java
@@ -15,6 +15,7 @@
  */
 package com.ververica.statefun.flink.core.feedback;
 
+import com.ververica.statefun.flink.core.common.MailboxExecutorFacade;
 import com.ververica.statefun.flink.core.common.SerializableFunction;
 import com.ververica.statefun.flink.core.common.SerializablePredicate;
 import com.ververica.statefun.flink.core.logger.Loggers;
@@ -127,7 +128,7 @@ public final class FeedbackUnionOperator<T> extends AbstractStreamOperator<T>
     // now we can start processing new messages. We do so by registering ourselves as a
     // FeedbackConsumer
     //
-    registerFeedbackConsumer(mailboxExecutor.asExecutor("Feedback Consumer"));
+    registerFeedbackConsumer(new MailboxExecutorFacade(mailboxExecutor, "Feedback Consumer"));
   }
 
   @Override

--- a/stateful-functions-flink/stateful-functions-flink-core/src/main/java/com/ververica/statefun/flink/core/functions/FunctionGroupOperator.java
+++ b/stateful-functions-flink/stateful-functions-flink-core/src/main/java/com/ververica/statefun/flink/core/functions/FunctionGroupOperator.java
@@ -18,6 +18,7 @@ package com.ververica.statefun.flink.core.functions;
 
 import com.ververica.statefun.flink.core.StatefulFunctionsUniverse;
 import com.ververica.statefun.flink.core.StatefulFunctionsUniverses;
+import com.ververica.statefun.flink.core.common.MailboxExecutorFacade;
 import com.ververica.statefun.flink.core.message.Message;
 import com.ververica.statefun.flink.core.message.MessageFactory;
 import com.ververica.statefun.flink.core.message.MessageTypeInformation;
@@ -112,7 +113,7 @@ public class FunctionGroupOperator extends AbstractStreamOperator<Message>
             sideOutputs,
             output,
             MessageFactory.forType(statefulFunctionsUniverse.messageFactoryType()),
-            mailboxExecutor.asExecutor("Stateful Functions Mailbox"),
+            new MailboxExecutorFacade(mailboxExecutor, "Stateful Functions Mailbox"),
             getRuntimeContext().getMetricGroup().addGroup("functions"),
             asyncOperationState,
             checkpointLockExecutor);


### PR DESCRIPTION
The commit apache/flink@e6c1b199f6bca620157acced1ece273e93d6e160 removed a method `MailboxExecutor#asExecutor`, which is used. This PR replaces that with a `MailboxExecutorFacade`
