### PR TITLE
[Docs] Issue #24 - ArtifactId of source sink dependency document miss "<"

### DIFF
--- a/stateful-functions-docs/docs/api_concepts/io_module/source_sink.rst
+++ b/stateful-functions-docs/docs/api_concepts/io_module/source_sink.rst
@@ -28,7 +28,7 @@ To use the Source/Sink I/O Module, please include the following dependency in yo
 
     <dependency>
         <groupId>com.ververica</groupId>
-        <artifactId>stateful-functions-flink-io/artifactId>
+        <artifactId>stateful-functions-flink-io</artifactId>
         <version>{version}</version>
         <scope>provided</scope>
     </dependency>


### PR DESCRIPTION
Document [source_sink](https://github.com/ververica/stateful-functions/blob/master/stateful-functions-docs/docs/api_concepts/io_module/source_sink.rst#dependency) add < to artifactId.