### PR TITLE
[README] Issue #26 -Fix class for usages of Harness

### DIFF
--- a/stateful-functions-examples/stateful-functions-flink-harness-example/README.md
+++ b/stateful-functions-examples/stateful-functions-flink-harness-example/README.md
@@ -3,9 +3,9 @@
 This is a simple example to demonstrate how one would run Stateful Functions application in the IDE using the
 provided Flink Harness.
 
-Take a look at the `com.ververica.statefun.examples.harness.Main` class to see example usages of `Harness`.
+Take a look at the `com.ververica.statefun.examples.harness.RunnerTest` class to see example usages of `Harness`.
 
 ## Running the example
 
-Simply run the `com.ververica.statefun.examples.harness.Main` class.
+Simply run the `com.ververica.statefun.examples.harness.RunnerTest` class.
 


### PR DESCRIPTION
Fix class for usages of Harness of README with following url [Running from the IDE](https://github.com/ververica/stateful-functions/tree/master/stateful-functions-examples/stateful-functions-flink-harness-example#using-the-flink-harness-to-run-stateful-functions-applications-in-the-ide)