### PR TITLE
EgressToSinkTranslator miss sink validation

### DIFF
--- a/stateful-functions-flink/stateful-functions-flink-core/src/main/java/com/ververica/statefun/flink/core/StatefulFunctionsUniverseValidator.java
+++ b/stateful-functions-flink/stateful-functions-flink-core/src/main/java/com/ververica/statefun/flink/core/StatefulFunctionsUniverseValidator.java
@@ -32,5 +32,8 @@ final class StatefulFunctionsUniverseValidator {
     if (statefulFunctionsUniverse.functions().isEmpty()) {
       throw new IllegalStateException("There are no function providers defined.");
     }
+    if (statefulFunctionsUniverse.sinks().isEmpty()) {
+      throw new IllegalStateException("There are no sink providers defined.");
+    }
   }
 }

--- a/stateful-functions-flink/stateful-functions-flink-core/src/main/java/com/ververica/statefun/flink/core/StatefulFunctionsUniverseValidator.java
+++ b/stateful-functions-flink/stateful-functions-flink-core/src/main/java/com/ververica/statefun/flink/core/StatefulFunctionsUniverseValidator.java
@@ -32,8 +32,5 @@ final class StatefulFunctionsUniverseValidator {
     if (statefulFunctionsUniverse.functions().isEmpty()) {
       throw new IllegalStateException("There are no function providers defined.");
     }
-    if (statefulFunctionsUniverse.sinks().isEmpty()) {
-      throw new IllegalStateException("There are no sink providers defined.");
-    }
   }
 }

--- a/stateful-functions-flink/stateful-functions-flink-core/src/main/java/com/ververica/statefun/flink/core/translation/EgressToSinkTranslator.java
+++ b/stateful-functions-flink/stateful-functions-flink-core/src/main/java/com/ververica/statefun/flink/core/translation/EgressToSinkTranslator.java
@@ -36,10 +36,20 @@ final class EgressToSinkTranslator {
     return Maps.transformValues(universe.egress(), this::sinkFromSpec);
   }
 
-  private DecoratedSink sinkFromSpec(EgressSpec<?> spec) {
+  private DecoratedSink sinkFromSpec(EgressIdentifier<?> key, EgressSpec<?> spec) {
     SinkProvider provider = universe.sinks().get(spec.type());
+    if (provider == null) {
+      throw new IllegalStateException(
+              "Unable to find a sink translation for egress of type "
+                      + spec.type()
+                      + ", which is bound for key "
+                      + key);
+    }
     SinkFunction<?> sink = provider.forSpec(spec);
-
+    if (sink == null) {
+      throw new NullPointerException(
+              "A sink provider for type " + spec.type() + ", has produced a NULL sink.");
+    }
     return DecoratedSink.of(spec, sink);
   }
 }


### PR DESCRIPTION
Class `EgressToSinkTranslator ` add sinks validation of `SinkProvider`. `EgressToSinkTranslator` check null case for SinkProvider.