### PR TITLE
Set TaskManager memory limit to 4GB

### DIFF
--- a/tools/docker/flink-distribution-template/conf/flink-conf.yaml
+++ b/tools/docker/flink-distribution-template/conf/flink-conf.yaml
@@ -21,4 +21,4 @@ state.backend: rocksdb
 state.backend.rocksdb.timer-service.factory: ROCKSDB
 state.checkpoints.dir: file:///checkpoint-dir
 state.backend.incremental: true
-
+taskmanager.memory.total-process.size: 4g


### PR DESCRIPTION
Following FLIP-49, now it is mandatory to specify
maximum allowed memory usage.