### PR TITLE
Add support to YAML based StatefulFunctionModules

### DIFF
--- a/stateful-functions-flink/stateful-functions-flink-core/pom.xml
+++ b/stateful-functions-flink/stateful-functions-flink-core/pom.xml
@@ -93,6 +93,12 @@ limitations under the License.
             <artifactId>jmh-generator-annprocess</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.google.jimfs</groupId>
+            <artifactId>jimfs</artifactId>
+            <version>1.1</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/stateful-functions-flink/stateful-functions-flink-core/src/main/java/com/ververica/statefun/flink/core/StatefulFunctionsJob.java
+++ b/stateful-functions-flink/stateful-functions-flink-core/src/main/java/com/ververica/statefun/flink/core/StatefulFunctionsJob.java
@@ -18,9 +18,12 @@ package com.ververica.statefun.flink.core;
 
 import com.ververica.statefun.flink.core.common.ConfigurationUtil;
 import com.ververica.statefun.flink.core.translation.FlinkUniverse;
+import java.net.URL;
+import java.net.URLClassLoader;
 import java.util.Objects;
 import org.apache.flink.api.java.utils.ParameterTool;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.execution.librarycache.FlinkUserCodeClassLoaders;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 
 public class StatefulFunctionsJob {
@@ -71,7 +74,10 @@ public class StatefulFunctionsJob {
   private static void setDefaultContextClassLoaderIfAbsent() {
     ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
     if (classLoader == null) {
-      Thread.currentThread().setContextClassLoader(StatefulFunctionsJob.class.getClassLoader());
+      URLClassLoader flinkClassLoader =
+          FlinkUserCodeClassLoaders.parentFirst(
+              new URL[0], StatefulFunctionsJob.class.getClassLoader());
+      Thread.currentThread().setContextClassLoader(flinkClassLoader);
     }
   }
 

--- a/stateful-functions-flink/stateful-functions-flink-core/src/main/java/com/ververica/statefun/flink/core/common/ResourceLocator.java
+++ b/stateful-functions-flink/stateful-functions-flink-core/src/main/java/com/ververica/statefun/flink/core/common/ResourceLocator.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2019 Ververica GmbH.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ververica.statefun.flink.core.common;
+
+import com.ververica.statefun.flink.core.jsonmodule.JsonServiceLoader;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URL;
+import java.util.Enumeration;
+import java.util.Iterator;
+import org.apache.flink.shaded.guava18.com.google.common.base.MoreObjects;
+
+public final class ResourceLocator {
+  private ResourceLocator() {}
+
+  /** Locates a resource with a given name in the classpath or url path. */
+  public static Iterable<URL> findNamedResources(String name) {
+    URI nameUri = URI.create(name);
+    if (!isClasspath(nameUri)) {
+      throw new IllegalArgumentException(
+          "unsupported schema " + nameUri.getScheme() + " only classpath: schema is supported.");
+    }
+    return urlClassPathResource(nameUri);
+  }
+
+  public static URL findNamedResource(String name) {
+    URI nameUri = URI.create(name);
+    if (isClasspath(nameUri)) {
+      Iterable<URL> resources = urlClassPathResource(nameUri);
+      return firstElementOrNull(resources);
+    }
+    try {
+      return nameUri.toURL();
+    } catch (MalformedURLException e) {
+      throw new IllegalArgumentException(e);
+    }
+  }
+
+  private static boolean isClasspath(URI nameUri) {
+    return nameUri.getScheme().equalsIgnoreCase("classpath");
+  }
+
+  private static Iterable<URL> urlClassPathResource(URI uri) {
+    ClassLoader cl =
+        MoreObjects.firstNonNull(
+            Thread.currentThread().getContextClassLoader(),
+            JsonServiceLoader.class.getClassLoader());
+    try {
+      Enumeration<URL> enumeration = cl.getResources(uri.getSchemeSpecificPart());
+      return asIterable(enumeration);
+    } catch (IOException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
+  private static URL firstElementOrNull(Iterable<URL> urls) {
+    for (URL url : urls) {
+      return url;
+    }
+    return null;
+  }
+
+  private static <T> Iterable<T> asIterable(Enumeration<T> enumeration) {
+    return () ->
+        new Iterator<T>() {
+          @Override
+          public boolean hasNext() {
+            return enumeration.hasMoreElements();
+          }
+
+          @Override
+          public T next() {
+            return enumeration.nextElement();
+          }
+        };
+  }
+}

--- a/stateful-functions-flink/stateful-functions-flink-core/src/main/java/com/ververica/statefun/flink/core/jsonmodule/JsonModule.java
+++ b/stateful-functions-flink/stateful-functions-flink-core/src/main/java/com/ververica/statefun/flink/core/jsonmodule/JsonModule.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright 2019 Ververica GmbH.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ververica.statefun.flink.core.jsonmodule;
+
+import static com.ververica.statefun.flink.core.jsonmodule.json.Pointers.Functions.META_TYPE;
+import static java.lang.String.format;
+import static java.util.stream.Collectors.toMap;
+
+import com.google.protobuf.Descriptors;
+import com.google.protobuf.DynamicMessage;
+import com.ververica.statefun.flink.core.common.ResourceLocator;
+import com.ververica.statefun.flink.core.jsonmodule.json.Pointers;
+import com.ververica.statefun.flink.core.jsonmodule.json.Selectors;
+import com.ververica.statefun.flink.core.jsonmodule.validation.ModuleConfigurationException;
+import com.ververica.statefun.flink.core.protorouter.ProtobufRouter;
+import com.ververica.statefun.flink.core.types.protobuf.ProtobufDescriptorMap;
+import com.ververica.statefun.flink.io.spi.JsonIngressSpec;
+import com.ververica.statefun.sdk.FunctionType;
+import com.ververica.statefun.sdk.IngressType;
+import com.ververica.statefun.sdk.io.IngressIdentifier;
+import com.ververica.statefun.sdk.io.Router;
+import com.ververica.statefun.sdk.spi.StatefulFunctionModule;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.URL;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.StreamSupport;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonNode;
+
+final class JsonModule implements StatefulFunctionModule {
+  private final JsonNode spec;
+  private final URL moduleUrl;
+
+  public JsonModule(JsonNode spec, URL moduleUrl) {
+    this.spec = Objects.requireNonNull(spec);
+    this.moduleUrl = Objects.requireNonNull(moduleUrl);
+  }
+
+  public void configure(Map<String, String> conf, Binder binder) {
+    try {
+      configureFunctions(binder, Selectors.listAt(spec, Pointers.FUNCTIONS_POINTER));
+      configureRouters(binder, Selectors.listAt(spec, Pointers.ROUTERS_POINTER));
+      configureIngress(binder, Selectors.listAt(spec, Pointers.INGRESSES_POINTER));
+    } catch (Throwable t) {
+      throw new ModuleConfigurationException(
+          format("Error while parsing module at %s", moduleUrl), t);
+    }
+  }
+
+  private void configureFunctions(Binder binder, Iterable<? extends JsonNode> functions) {
+    final Map<FunctionType, RemoteFunctionSpec> definedFunctions =
+        StreamSupport.stream(functions.spliterator(), false)
+            .map(JsonModule::parseRemoteFunctionSpec)
+            .collect(toMap(RemoteFunctionSpec::functionType, Function.identity()));
+
+    // currently we had a single function type that can be specified at a module.yaml
+    // and this is the RemoteFunction. Therefore we translate immediately the function spec
+    // to a (GRPC) RemoteFunctionProvider.
+    RemoteFunctionProvider provider = new RemoteFunctionProvider(definedFunctions);
+    for (FunctionType type : definedFunctions.keySet()) {
+      binder.bindFunctionProvider(type, provider);
+    }
+  }
+
+  private void configureRouters(Binder binder, Iterable<? extends JsonNode> routerNodes) {
+    for (JsonNode router : routerNodes) {
+      // currently the only type of router supported in a module.yaml, is a protobuf dynamicMessage
+      // router once we will introduce further router types we should refactor this to be more
+      // dynamic.
+      requireProtobufRouterType(router);
+
+      IngressIdentifier<DynamicMessage> id = targetRouterIngress(router);
+      binder.bindIngressRouter(id, dynamicRouter(router));
+    }
+  }
+
+  private void configureIngress(Binder binder, Iterable<? extends JsonNode> ingressNode) {
+    for (JsonNode ingress : ingressNode) {
+      IngressIdentifier<DynamicMessage> id = ingressId(ingress);
+      IngressType type = ingressType(ingress);
+
+      JsonIngressSpec<DynamicMessage> ingressSpec = new JsonIngressSpec<>(type, id, ingress);
+      binder.bindIngress(ingressSpec);
+    }
+  }
+
+  // ----------------------------------------------------------------------------------------------------------
+  // Ingresses
+  // ----------------------------------------------------------------------------------------------------------
+
+  private static IngressType ingressType(JsonNode spec) {
+    String typeString = Selectors.textAt(spec, Pointers.Ingress.META_TYPE);
+    NamespaceNamePair nn = NamespaceNamePair.from(typeString);
+    return new IngressType(nn.namespace, nn.name);
+  }
+
+  private static IngressIdentifier<DynamicMessage> ingressId(JsonNode ingress) {
+    String ingressId = Selectors.textAt(ingress, Pointers.Ingress.META_ID);
+    NamespaceNamePair nn = NamespaceNamePair.from(ingressId);
+    return new IngressIdentifier<>(DynamicMessage.class, nn.namespace, nn.name);
+  }
+
+  // ----------------------------------------------------------------------------------------------------------
+  // Routers
+  // ----------------------------------------------------------------------------------------------------------
+
+  private static Router<DynamicMessage> dynamicRouter(JsonNode router) {
+    String addressTemplate = Selectors.textAt(router, Pointers.Routers.SPEC_TARGET);
+    String descriptorSetPath = Selectors.textAt(router, Pointers.Routers.SPEC_DESCRIPTOR);
+    String messageType = Selectors.textAt(router, Pointers.Routers.SPEC_MESSAGE_TYPE);
+
+    ProtobufDescriptorMap descriptorPath = protobufDescriptorMap(descriptorSetPath);
+    Optional<Descriptors.GenericDescriptor> maybeDescriptor =
+        descriptorPath.getDescriptorByName(messageType);
+    if (!maybeDescriptor.isPresent()) {
+      throw new IllegalStateException(
+          "Error while processing a router definition. Unable to read the descriptor set locate at  "
+              + descriptorSetPath);
+    }
+    return ProtobufRouter.forAddressTemplate(
+        (Descriptors.Descriptor) maybeDescriptor.get(), addressTemplate);
+  }
+
+  private static ProtobufDescriptorMap protobufDescriptorMap(String descriptorSetPath) {
+    try {
+      URL url = ResourceLocator.findNamedResource(descriptorSetPath);
+      return ProtobufDescriptorMap.from(url);
+    } catch (IOException e) {
+      throw new IllegalStateException(
+          "Error while processing a router definition. Unable to read the descriptor set at  "
+              + descriptorSetPath,
+          e);
+    }
+  }
+
+  private static IngressIdentifier<DynamicMessage> targetRouterIngress(JsonNode routerNode) {
+    String targetIngress = Selectors.textAt(routerNode, Pointers.Routers.SPEC_INGRESS);
+    NamespaceNamePair nn = NamespaceNamePair.from(targetIngress);
+    return new IngressIdentifier<>(DynamicMessage.class, nn.namespace, nn.name);
+  }
+
+  private static void requireProtobufRouterType(JsonNode routerNode) {
+    String routerType = Selectors.textAt(routerNode, Pointers.Routers.META_TYPE);
+    if (!routerType.equalsIgnoreCase("com.ververica.statefun.sdk/protobuf-router")) {
+      throw new IllegalStateException("Invalid router type " + routerType);
+    }
+  }
+
+  // ----------------------------------------------------------------------------------------------------------
+  // Functions
+  // ----------------------------------------------------------------------------------------------------------
+
+  private static RemoteFunctionSpec parseRemoteFunctionSpec(JsonNode functionNode) {
+    FunctionType functionType = functionType(functionNode);
+    InetSocketAddress functionAddress = functionAddress(functionNode);
+    return new RemoteFunctionSpec(functionType, functionAddress);
+  }
+
+  private static FunctionType functionType(JsonNode functionNode) {
+    String namespaceName = Selectors.textAt(functionNode, META_TYPE);
+    NamespaceNamePair nn = NamespaceNamePair.from(namespaceName);
+    return new FunctionType(nn.namespace, nn.name);
+  }
+
+  private static InetSocketAddress functionAddress(JsonNode functionNode) {
+    String host = Selectors.textAt(functionNode, Pointers.Functions.FUNCTION_HOSTNAME);
+    int port = Selectors.integerAt(functionNode, Pointers.Functions.FUNCTION_PORT);
+    return new InetSocketAddress(host, port);
+  }
+}

--- a/stateful-functions-flink/stateful-functions-flink-core/src/main/java/com/ververica/statefun/flink/core/jsonmodule/JsonServiceLoader.java
+++ b/stateful-functions-flink/stateful-functions-flink-core/src/main/java/com/ververica/statefun/flink/core/jsonmodule/JsonServiceLoader.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2019 Ververica GmbH.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ververica.statefun.flink.core.jsonmodule;
+
+import static com.ververica.statefun.flink.core.common.ResourceLocator.findNamedResources;
+import static com.ververica.statefun.flink.core.jsonmodule.json.Pointers.MODULE_META_TYPE;
+import static com.ververica.statefun.flink.core.jsonmodule.json.Pointers.MODULE_SPEC;
+
+import com.ververica.statefun.flink.core.spi.Constants;
+import com.ververica.statefun.sdk.spi.StatefulFunctionModule;
+import java.io.IOException;
+import java.net.URL;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonNode;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+
+public final class JsonServiceLoader {
+
+  public static Iterable<StatefulFunctionModule> load() {
+    ObjectMapper mapper = mapper();
+
+    Iterable<URL> namedResources =
+        findNamedResources("classpath:" + Constants.STATEFUL_FUNCTIONS_MODULE_NAME);
+
+    return StreamSupport.stream(namedResources.spliterator(), false)
+        .map(moduleUrl -> fromUrl(mapper, moduleUrl))
+        .collect(Collectors.toList());
+  }
+
+  @VisibleForTesting
+  static StatefulFunctionModule fromUrl(ObjectMapper mapper, URL moduleUrl) {
+    try {
+      JsonNode root = readAndValidateModuleTree(mapper, moduleUrl);
+      JsonNode spec = root.at(MODULE_SPEC);
+      return new JsonModule(spec, moduleUrl);
+    } catch (Throwable t) {
+      throw new RuntimeException("Failed loading a module at " + moduleUrl, t);
+    }
+  }
+
+  /**
+   * Read a {@code StatefulFunction} module definition.
+   *
+   * <p>A valid resource module definition has to contain the following sections:
+   *
+   * <ul>
+   *   <li>meta - contains the metadata associated with this module, such as its type.
+   *   <li>spec - a specification of the module. i.e. the definied functions, routers etc'.
+   * </ul>
+   *
+   * <p>If any of these sections are missing, this would be considered an invalid module definition,
+   * in addition a type is a mandatory field of a module spec.
+   */
+  private static JsonNode readAndValidateModuleTree(ObjectMapper mapper, URL moduleYamlFile)
+      throws IOException {
+    JsonNode root = mapper.readTree(moduleYamlFile);
+    validateMeta(moduleYamlFile, root);
+    validateSpec(moduleYamlFile, root);
+    return root;
+  }
+
+  private static void validateMeta(URL moduleYamlFile, JsonNode root) {
+    JsonNode typeNode = root.at(MODULE_META_TYPE);
+    if (typeNode.isMissingNode()) {
+      throw new IllegalStateException("Unable to find a module type in " + moduleYamlFile);
+    }
+    if (!typeNode.asText().equalsIgnoreCase(ModuleType.REMOTE.name())) {
+      throw new IllegalStateException(
+          "Unknown module type "
+              + typeNode.asText()
+              + ", currently supported: "
+              + ModuleType.REMOTE);
+    }
+  }
+
+  private static void validateSpec(URL moduleYamlFile, JsonNode root) {
+    if (root.at(MODULE_SPEC).isMissingNode()) {
+      throw new IllegalStateException("A module without a spec at " + moduleYamlFile);
+    }
+  }
+
+  @VisibleForTesting
+  static ObjectMapper mapper() {
+    return new ObjectMapper(new YAMLFactory());
+  }
+}

--- a/stateful-functions-flink/stateful-functions-flink-core/src/main/java/com/ververica/statefun/flink/core/jsonmodule/ModuleType.java
+++ b/stateful-functions-flink/stateful-functions-flink-core/src/main/java/com/ververica/statefun/flink/core/jsonmodule/ModuleType.java
@@ -13,11 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package com.ververica.statefun.flink.core.jsonmodule;
 
-package com.ververica.statefun.flink.launcher;
-
-public class Constants {
-  static final String MODULE_DIRECTORY = "/opt/stateful-functions/modules";
-  static final String FLINK_JOB_JAR_PATH = "/opt/flink/lib/stateful-functions-flink-core.jar";
-  static final String STATEFUL_FUNCTIONS_PACKAGE = "com.ververica.statefun.";
+public enum ModuleType {
+  REMOTE
 }

--- a/stateful-functions-flink/stateful-functions-flink-core/src/main/java/com/ververica/statefun/flink/core/jsonmodule/NamespaceNamePair.java
+++ b/stateful-functions-flink/stateful-functions-flink-core/src/main/java/com/ververica/statefun/flink/core/jsonmodule/NamespaceNamePair.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2019 Ververica GmbH.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ververica.statefun.flink.core.jsonmodule;
+
+import java.util.Objects;
+
+final class NamespaceNamePair {
+  public final String namespace;
+  public final String name;
+
+  public static NamespaceNamePair from(String namespaceAndName) {
+    Objects.requireNonNull(namespaceAndName);
+    final int pos = namespaceAndName.lastIndexOf("/");
+    if (pos <= 0 || pos == namespaceAndName.length() - 1) {
+      throw new IllegalArgumentException(
+          namespaceAndName + " does not conform to the <namespace>/<name> format");
+    }
+    String namespace = namespaceAndName.substring(0, pos);
+    String name = namespaceAndName.substring(pos + 1);
+    return new NamespaceNamePair(namespace, name);
+  }
+
+  private NamespaceNamePair(String namespace, String name) {
+    this.namespace = Objects.requireNonNull(namespace);
+    this.name = Objects.requireNonNull(name);
+  }
+}

--- a/stateful-functions-flink/stateful-functions-flink-core/src/main/java/com/ververica/statefun/flink/core/jsonmodule/RemoteFunction.java
+++ b/stateful-functions-flink/stateful-functions-flink-core/src/main/java/com/ververica/statefun/flink/core/jsonmodule/RemoteFunction.java
@@ -13,26 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package com.ververica.statefun.flink.core.jsonmodule;
 
-package com.ververica.statefun.flink.core.common;
+import com.ververica.statefun.sdk.Context;
+import com.ververica.statefun.sdk.StatefulFunction;
+import java.util.Objects;
 
-import java.io.Closeable;
-import javax.annotation.Nonnull;
+public class RemoteFunction implements StatefulFunction {
+  private final RemoteFunctionSpec functionSpec;
 
-public final class SetContextClassLoader implements Closeable {
-  private final ClassLoader originalClassLoader;
-
-  public SetContextClassLoader(@Nonnull Object o) {
-    this(o.getClass().getClassLoader());
-  }
-
-  public SetContextClassLoader(@Nonnull ClassLoader classLoader) {
-    this.originalClassLoader = Thread.currentThread().getContextClassLoader();
-    Thread.currentThread().setContextClassLoader(classLoader);
+  public RemoteFunction(RemoteFunctionSpec functionSpec) {
+    this.functionSpec = Objects.requireNonNull(functionSpec);
   }
 
   @Override
-  public void close() {
-    Thread.currentThread().setContextClassLoader(originalClassLoader);
+  public void invoke(Context context, Object input) {
+    throw new UnsupportedOperationException(functionSpec.functionType() + " is not yet supported.");
   }
 }

--- a/stateful-functions-flink/stateful-functions-flink-core/src/main/java/com/ververica/statefun/flink/core/jsonmodule/RemoteFunctionProvider.java
+++ b/stateful-functions-flink/stateful-functions-flink-core/src/main/java/com/ververica/statefun/flink/core/jsonmodule/RemoteFunctionProvider.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019 Ververica GmbH.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ververica.statefun.flink.core.jsonmodule;
+
+import com.ververica.statefun.sdk.FunctionType;
+import com.ververica.statefun.sdk.StatefulFunction;
+import com.ververica.statefun.sdk.StatefulFunctionProvider;
+import java.util.Map;
+
+public class RemoteFunctionProvider implements StatefulFunctionProvider {
+  private final Map<FunctionType, RemoteFunctionSpec> supportedTypes;
+
+  public RemoteFunctionProvider(Map<FunctionType, RemoteFunctionSpec> supportedTypes) {
+    this.supportedTypes = supportedTypes;
+  }
+
+  @Override
+  public StatefulFunction functionOfType(FunctionType type) {
+    RemoteFunctionSpec spec = supportedTypes.get(type);
+    if (spec == null) {
+      throw new IllegalArgumentException("Unsupported type " + type);
+    }
+    return new RemoteFunction(spec);
+  }
+}

--- a/stateful-functions-flink/stateful-functions-flink-core/src/main/java/com/ververica/statefun/flink/core/jsonmodule/RemoteFunctionSpec.java
+++ b/stateful-functions-flink/stateful-functions-flink-core/src/main/java/com/ververica/statefun/flink/core/jsonmodule/RemoteFunctionSpec.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019 Ververica GmbH.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ververica.statefun.flink.core.jsonmodule;
+
+import com.ververica.statefun.sdk.FunctionType;
+import java.net.SocketAddress;
+import java.util.Objects;
+
+final class RemoteFunctionSpec {
+  private final FunctionType functionType;
+  private final SocketAddress functionAddress;
+
+  RemoteFunctionSpec(FunctionType functionType, SocketAddress functionAddress) {
+    this.functionType = Objects.requireNonNull(functionType);
+    this.functionAddress = Objects.requireNonNull(functionAddress);
+  }
+
+  FunctionType functionType() {
+    return functionType;
+  }
+
+  SocketAddress address() {
+    return functionAddress;
+  }
+}

--- a/stateful-functions-flink/stateful-functions-flink-core/src/main/java/com/ververica/statefun/flink/core/jsonmodule/json/Pointers.java
+++ b/stateful-functions-flink/stateful-functions-flink-core/src/main/java/com/ververica/statefun/flink/core/jsonmodule/json/Pointers.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2019 Ververica GmbH.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ververica.statefun.flink.core.jsonmodule.json;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonPointer;
+
+public final class Pointers {
+
+  private Pointers() {}
+
+  // -------------------------------------------------------------------------------------
+  // top level spec definition
+  // -------------------------------------------------------------------------------------
+
+  public static final JsonPointer MODULE_META_TYPE = JsonPointer.compile("/module/meta/type");
+  public static final JsonPointer MODULE_SPEC = JsonPointer.compile("/module/spec");
+  public static final JsonPointer FUNCTIONS_POINTER = JsonPointer.compile("/functions");
+  public static final JsonPointer ROUTERS_POINTER = JsonPointer.compile("/routers");
+  public static final JsonPointer INGRESSES_POINTER = JsonPointer.compile("/ingresses");
+  public static final JsonPointer EGRESSES_POINTER = JsonPointer.compile("/egresses");
+
+  // -------------------------------------------------------------------------------------
+  // function
+  // -------------------------------------------------------------------------------------
+
+  public static final class Functions {
+    public static final JsonPointer META_TYPE = JsonPointer.compile("/function/meta/type");
+    public static final JsonPointer FUNCTION_HOSTNAME = JsonPointer.compile("/function/spec/host");
+    public static final JsonPointer FUNCTION_PORT = JsonPointer.compile("/function/spec/port");
+  }
+
+  // -------------------------------------------------------------------------------------
+  // routers
+  // -------------------------------------------------------------------------------------
+
+  public static final class Routers {
+
+    public static final JsonPointer META_TYPE = JsonPointer.compile("/router/meta/type");
+    public static final JsonPointer SPEC_INGRESS = JsonPointer.compile("/router/spec/ingress");
+    public static final JsonPointer SPEC_TARGET = JsonPointer.compile("/router/spec/target");
+    public static final JsonPointer SPEC_DESCRIPTOR =
+        JsonPointer.compile("/router/spec/descriptorSet");
+    public static final JsonPointer SPEC_MESSAGE_TYPE =
+        JsonPointer.compile("/router/spec/messageType");
+  }
+
+  // -------------------------------------------------------------------------------------
+  // ingresses
+  // -------------------------------------------------------------------------------------
+
+  public static final class Ingress {
+
+    public static final JsonPointer META_ID = JsonPointer.compile("/ingress/meta/id");
+    public static final JsonPointer META_TYPE = JsonPointer.compile("/ingress/meta/type");
+  }
+}

--- a/stateful-functions-flink/stateful-functions-flink-core/src/main/java/com/ververica/statefun/flink/core/jsonmodule/json/Selectors.java
+++ b/stateful-functions-flink/stateful-functions-flink-core/src/main/java/com/ververica/statefun/flink/core/jsonmodule/json/Selectors.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2019 Ververica GmbH.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ververica.statefun.flink.core.jsonmodule.json;
+
+import com.ververica.statefun.flink.core.jsonmodule.validation.MissingKeyException;
+import com.ververica.statefun.flink.core.jsonmodule.validation.WrongTypeException;
+import java.util.Collections;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonPointer;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonNode;
+
+public final class Selectors {
+
+  public static String textAt(JsonNode node, JsonPointer pointer) {
+    node = dereference(node, pointer);
+    if (!node.isTextual()) {
+      throw new WrongTypeException(pointer, "not a string");
+    }
+    return node.asText();
+  }
+
+  public static int integerAt(JsonNode node, JsonPointer pointer) {
+    node = dereference(node, pointer);
+    if (!node.isInt()) {
+      throw new WrongTypeException(pointer, "not an integer");
+    }
+    return node.asInt();
+  }
+
+  public static Iterable<? extends JsonNode> listAt(JsonNode node, JsonPointer pointer) {
+    node = node.at(pointer);
+    if (node.isMissingNode()) {
+      return Collections.emptyList();
+    }
+    if (!node.isArray()) {
+      throw new WrongTypeException(pointer, " not a list");
+    }
+    return node;
+  }
+
+  private static JsonNode dereference(JsonNode node, JsonPointer pointer) {
+    node = node.at(pointer);
+    if (node.isMissingNode()) {
+      throw new MissingKeyException(pointer);
+    }
+    return node;
+  }
+}

--- a/stateful-functions-flink/stateful-functions-flink-core/src/main/java/com/ververica/statefun/flink/core/jsonmodule/validation/MissingKeyException.java
+++ b/stateful-functions-flink/stateful-functions-flink-core/src/main/java/com/ververica/statefun/flink/core/jsonmodule/validation/MissingKeyException.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019 Ververica GmbH.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ververica.statefun.flink.core.jsonmodule.validation;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonPointer;
+
+public class MissingKeyException extends RuntimeException {
+
+  private static final long serialVersionUID = 1;
+
+  public MissingKeyException(JsonPointer pointer) {
+    super("missing key " + pointer.toString());
+  }
+}

--- a/stateful-functions-flink/stateful-functions-flink-core/src/main/java/com/ververica/statefun/flink/core/jsonmodule/validation/ModuleConfigurationException.java
+++ b/stateful-functions-flink/stateful-functions-flink-core/src/main/java/com/ververica/statefun/flink/core/jsonmodule/validation/ModuleConfigurationException.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2019 Ververica GmbH.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ververica.statefun.flink.core.jsonmodule.validation;
+
+public final class ModuleConfigurationException extends RuntimeException {
+  private static final long serialVersionUID = 1;
+
+  public ModuleConfigurationException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/stateful-functions-flink/stateful-functions-flink-core/src/main/java/com/ververica/statefun/flink/core/jsonmodule/validation/WrongTypeException.java
+++ b/stateful-functions-flink/stateful-functions-flink-core/src/main/java/com/ververica/statefun/flink/core/jsonmodule/validation/WrongTypeException.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019 Ververica GmbH.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ververica.statefun.flink.core.jsonmodule.validation;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonPointer;
+
+public class WrongTypeException extends RuntimeException {
+
+  private static final long serialVersionUID = 1;
+
+  public WrongTypeException(JsonPointer pointer, String message) {
+    super("Wrong type for key " + pointer + " " + message);
+  }
+}

--- a/stateful-functions-flink/stateful-functions-flink-core/src/main/java/com/ververica/statefun/flink/core/spi/Constants.java
+++ b/stateful-functions-flink/stateful-functions-flink-core/src/main/java/com/ververica/statefun/flink/core/spi/Constants.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019 Ververica GmbH.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.statefun.flink.core.spi;
+
+public class Constants {
+  private Constants() {}
+
+  public static final String MODULE_DIRECTORY = "/opt/stateful-functions/modules";
+  public static final String FLINK_JOB_JAR_PATH =
+      "/opt/flink/lib/stateful-functions-flink-core.jar";
+  public static final String STATEFUL_FUNCTIONS_PACKAGE = "com.ververica.statefun.";
+  public static final String STATEFUL_FUNCTIONS_MODULE_NAME = "module.yaml";
+}

--- a/stateful-functions-flink/stateful-functions-flink-core/src/main/java/com/ververica/statefun/flink/core/spi/Modules.java
+++ b/stateful-functions-flink/stateful-functions-flink-core/src/main/java/com/ververica/statefun/flink/core/spi/Modules.java
@@ -19,14 +19,11 @@ package com.ververica.statefun.flink.core.spi;
 import com.ververica.statefun.flink.core.StatefulFunctionsJobConstants;
 import com.ververica.statefun.flink.core.StatefulFunctionsUniverse;
 import com.ververica.statefun.flink.core.common.SetContextClassLoader;
+import com.ververica.statefun.flink.core.jsonmodule.JsonServiceLoader;
 import com.ververica.statefun.flink.core.message.MessageFactoryType;
 import com.ververica.statefun.flink.io.spi.FlinkIoModule;
 import com.ververica.statefun.sdk.spi.StatefulFunctionModule;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.ServiceLoader;
+import java.util.*;
 import org.apache.flink.configuration.Configuration;
 
 public final class Modules {
@@ -44,6 +41,9 @@ public final class Modules {
     List<FlinkIoModule> ioModules = new ArrayList<>();
 
     for (StatefulFunctionModule provider : ServiceLoader.load(StatefulFunctionModule.class)) {
+      statefulFunctionModules.add(provider);
+    }
+    for (StatefulFunctionModule provider : JsonServiceLoader.load()) {
       statefulFunctionModules.add(provider);
     }
     for (FlinkIoModule provider : ServiceLoader.load(FlinkIoModule.class)) {

--- a/stateful-functions-flink/stateful-functions-flink-core/src/main/java/com/ververica/statefun/flink/core/types/protobuf/ProtobufDescriptorMap.java
+++ b/stateful-functions-flink/stateful-functions-flink-core/src/main/java/com/ververica/statefun/flink/core/types/protobuf/ProtobufDescriptorMap.java
@@ -19,6 +19,8 @@ import com.google.protobuf.DescriptorProtos;
 import com.google.protobuf.Descriptors;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
 import java.nio.file.Files;
 import java.util.HashMap;
 import java.util.Map;
@@ -31,6 +33,14 @@ public final class ProtobufDescriptorMap {
     byte[] descriptorBytes = Files.readAllBytes(file.toPath());
     DescriptorProtos.FileDescriptorSet fileDescriptorSet =
         DescriptorProtos.FileDescriptorSet.parseFrom(descriptorBytes);
+    return from(fileDescriptorSet);
+  }
+
+  public static ProtobufDescriptorMap from(URL fileDescriptorUrl) throws IOException {
+    InputStream stream = fileDescriptorUrl.openStream();
+
+    DescriptorProtos.FileDescriptorSet fileDescriptorSet =
+        DescriptorProtos.FileDescriptorSet.parseFrom(stream);
     return from(fileDescriptorSet);
   }
 

--- a/stateful-functions-flink/stateful-functions-flink-core/src/test/java/com/ververica/statefun/flink/core/common/ResourceLocatorTest.java
+++ b/stateful-functions-flink/stateful-functions-flink-core/src/test/java/com/ververica/statefun/flink/core/common/ResourceLocatorTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2019 Ververica GmbH.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.statefun.flink.core.common;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.assertThat;
+
+import com.google.common.jimfs.Configuration;
+import com.google.common.jimfs.Jimfs;
+import com.ververica.statefun.flink.core.spi.Constants;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.FileSystem;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collection;
+import org.apache.commons.io.Charsets;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class ResourceLocatorTest {
+
+  @Parameterized.Parameters
+  public static Collection<Configuration> filesystemTypes() {
+    return Arrays.asList(Configuration.unix(), Configuration.osX(), Configuration.windows());
+  }
+
+  private final FileSystem fileSystem;
+
+  public ResourceLocatorTest(Configuration filesystemConfiguration) {
+    this.fileSystem = Jimfs.newFileSystem(filesystemConfiguration);
+  }
+
+  @Test
+  public void classPathExample() throws IOException {
+    final Path firstModuleDir = createDirectoryWithAFile("first", "module.yaml");
+    final Path secondModuleDir = createDirectoryWithAFile("second", "module.yaml");
+
+    ClassLoader urlClassLoader = urlClassLoader(firstModuleDir, secondModuleDir);
+
+    try (SetContextClassLoader ignored = new SetContextClassLoader(urlClassLoader)) {
+
+      Iterable<URL> foundUrls =
+          ResourceLocator.findNamedResources(
+              "classpath:" + Constants.STATEFUL_FUNCTIONS_MODULE_NAME);
+
+      assertThat(
+          foundUrls,
+          contains(
+              url(firstModuleDir.resolve("module.yaml")),
+              url(secondModuleDir.resolve("module.yaml"))));
+    }
+  }
+
+  @Test
+  public void classPathSingleResourceExample() {
+    URL url = ResourceLocator.findNamedResource("classpath:test-descriptors.bin");
+
+    assertThat(url, notNullValue());
+  }
+
+  @Test
+  public void absolutePathExample() throws IOException {
+    Path modulePath = createDirectoryWithAFile("some-module", "module.yaml").resolve("module.yaml");
+
+    URL url = ResourceLocator.findNamedResource(modulePath.toUri().toString());
+
+    assertThat(url, is(url(modulePath)));
+  }
+
+  private Path createDirectoryWithAFile(
+      String basedir, @SuppressWarnings("SameParameterValue") String filename) throws IOException {
+    final Path dir = fileSystem.getPath(basedir);
+    Files.createDirectories(dir);
+
+    Path file = dir.resolve(filename);
+    Files.write(file, "hello world".getBytes(Charsets.UTF_8));
+
+    return dir;
+  }
+
+  private static ClassLoader urlClassLoader(Path... urlPath) {
+    URL[] urls = Arrays.stream(urlPath).map(ResourceLocatorTest::url).toArray(URL[]::new);
+    return new URLClassLoader(urls);
+  }
+
+  private static URL url(Path path) {
+    try {
+      return path.toUri().toURL();
+    } catch (MalformedURLException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/stateful-functions-flink/stateful-functions-flink-core/src/test/java/com/ververica/statefun/flink/core/jsonmodule/JsonModuleTest.java
+++ b/stateful-functions-flink/stateful-functions-flink-core/src/test/java/com/ververica/statefun/flink/core/jsonmodule/JsonModuleTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2019 Ververica GmbH.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ververica.statefun.flink.core.jsonmodule;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.assertThat;
+
+import com.google.protobuf.DynamicMessage;
+import com.ververica.statefun.flink.core.StatefulFunctionsUniverse;
+import com.ververica.statefun.flink.core.message.MessageFactoryType;
+import com.ververica.statefun.sdk.FunctionType;
+import com.ververica.statefun.sdk.io.IngressIdentifier;
+import com.ververica.statefun.sdk.spi.StatefulFunctionModule;
+import java.io.IOException;
+import java.net.URL;
+import java.util.Collections;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonNode;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
+
+public class JsonModuleTest {
+
+  @Test
+  public void exampleUsage() {
+    StatefulFunctionModule module = fromPath("bar-module/module.yaml");
+
+    assertThat(module, notNullValue());
+  }
+
+  @Test
+  public void testFunctions() {
+    StatefulFunctionModule module = fromPath("bar-module/module.yaml");
+
+    StatefulFunctionsUniverse universe = emptyUniverse();
+    module.configure(Collections.emptyMap(), universe);
+
+    assertThat(
+        universe.functions(),
+        allOf(
+            hasKey(new FunctionType("com.example", "hello")),
+            hasKey(new FunctionType("com.foo", "world"))));
+  }
+
+  @Test
+  public void testRouters() {
+    StatefulFunctionModule module = fromPath("bar-module/module.yaml");
+
+    StatefulFunctionsUniverse universe = emptyUniverse();
+    module.configure(Collections.emptyMap(), universe);
+
+    assertThat(
+        universe.routers(),
+        hasKey(new IngressIdentifier<>(DynamicMessage.class, "com.mycomp.igal", "names")));
+  }
+
+  private static StatefulFunctionModule fromPath(String path) {
+    URL moduleUrl = JsonServiceLoader.class.getClassLoader().getResource(path);
+    ObjectMapper mapper = JsonServiceLoader.mapper();
+    final JsonNode json;
+    try {
+      json = mapper.readTree(moduleUrl);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+    JsonNode spec = json.at("/module/spec");
+    return new JsonModule(spec, moduleUrl);
+  }
+
+  private static StatefulFunctionsUniverse emptyUniverse() {
+    return new StatefulFunctionsUniverse(MessageFactoryType.WITH_PROTOBUF_PAYLOADS);
+  }
+}

--- a/stateful-functions-flink/stateful-functions-flink-core/src/test/resources/bar-module/module.yaml
+++ b/stateful-functions-flink/stateful-functions-flink-core/src/test/resources/bar-module/module.yaml
@@ -1,0 +1,54 @@
+#
+# Copyright 2019 Ververica GmbH.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+module:
+  meta:
+    type: remote
+  spec:
+    functions:
+      - function:
+          meta:
+            type: com.example/hello
+          spec:
+            host: localhost
+            port: 5000
+      - function:
+          meta:
+            type: com.foo/world
+          spec:
+            host: localhost
+            port: 8855
+    routers:
+      - router:
+          meta:
+            type: com.ververica.statefun.sdk/protobuf-router
+          spec:
+            ingress: com.mycomp.igal/names
+            target: "com.example/hello/{{$.name}}"
+            messageType: com.ververica.test.SimpleMessage
+            descriptorSet: classpath:test-descriptors.bin
+    ingressess:
+      - ingress:
+          meta:
+            type: com.ververica.statefun.sdk.kafka/universal-kafka-connector
+            id: com.mycomp.igal/names
+          spec:
+            address: kafka-broker:9092
+            topics:
+              - names
+            properties:
+              - consumer.group: greeter
+            messageType: com.ververica.test.SimpleMessage
+            descriptorSet: classpath:test-descriptors.bin

--- a/stateful-functions-flink/stateful-functions-flink-core/src/test/resources/foo-module/module.yaml
+++ b/stateful-functions-flink/stateful-functions-flink-core/src/test/resources/foo-module/module.yaml
@@ -1,0 +1,26 @@
+#
+# Copyright 2019 Ververica GmbH.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+module:
+  meta:
+    type: remote
+  spec:
+    functions:
+      function:
+        meta:
+          type: com.example/hello
+        spec:
+          host: localhost
+          port: 5000

--- a/stateful-functions-flink/stateful-functions-flink-io/src/main/java/com/ververica/statefun/flink/io/datastream/SourceSinkModule.java
+++ b/stateful-functions-flink/stateful-functions-flink-io/src/main/java/com/ververica/statefun/flink/io/datastream/SourceSinkModule.java
@@ -41,12 +41,18 @@ public class SourceSinkModule implements FlinkIoModule {
 
     @Override
     public <T> SourceFunction<T> forSpec(IngressSpec<T> spec) {
+      if (!(spec instanceof SourceFunctionSpec)) {
+        throw new IllegalStateException("spec " + spec + " is not of type SourceFunctionSpec");
+      }
       SourceFunctionSpec<T> casted = (SourceFunctionSpec<T>) spec;
       return casted.delegate();
     }
 
     @Override
     public <T> SinkFunction<T> forSpec(EgressSpec<T> spec) {
+      if (!(spec instanceof SinkFunctionSpec)) {
+        throw new IllegalStateException("spec " + spec + " is not of type SourceFunctionSpec");
+      }
       SinkFunctionSpec<T> casted = (SinkFunctionSpec<T>) spec;
       return casted.delegate();
     }

--- a/stateful-functions-flink/stateful-functions-flink-io/src/main/java/com/ververica/statefun/flink/io/spi/JsonIngressSpec.java
+++ b/stateful-functions-flink/stateful-functions-flink-io/src/main/java/com/ververica/statefun/flink/io/spi/JsonIngressSpec.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2019 Ververica GmbH.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ververica.statefun.flink.io.spi;
+
+import com.ververica.statefun.sdk.IngressType;
+import com.ververica.statefun.sdk.io.IngressIdentifier;
+import com.ververica.statefun.sdk.io.IngressSpec;
+import java.util.Objects;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonNode;
+
+public final class JsonIngressSpec<T> implements IngressSpec<T> {
+  private final JsonNode json;
+  private final IngressIdentifier<T> id;
+  private final IngressType type;
+
+  public JsonIngressSpec(IngressType type, IngressIdentifier<T> id, JsonNode json) {
+    this.type = Objects.requireNonNull(type);
+    this.id = Objects.requireNonNull(id);
+    this.json = Objects.requireNonNull(json);
+  }
+
+  @Override
+  public IngressType type() {
+    return type;
+  }
+
+  @Override
+  public IngressIdentifier<T> id() {
+    return id;
+  }
+
+  public JsonNode json() {
+    return json;
+  }
+}

--- a/stateful-functions-flink/stateful-functions-flink-launcher/src/main/java/com/ververica/statefun/flink/launcher/StatefulFunctionsClusterEntryPoint.java
+++ b/stateful-functions-flink/stateful-functions-flink-launcher/src/main/java/com/ververica/statefun/flink/launcher/StatefulFunctionsClusterEntryPoint.java
@@ -18,6 +18,7 @@ package com.ververica.statefun.flink.launcher;
 
 import static java.util.Objects.requireNonNull;
 
+import com.ververica.statefun.flink.core.spi.Constants;
 import java.util.Optional;
 import javax.annotation.Nonnull;
 import org.apache.flink.annotation.VisibleForTesting;

--- a/stateful-functions-flink/stateful-functions-flink-launcher/src/main/java/com/ververica/statefun/flink/launcher/StatefulFunctionsJobGraphRetriever.java
+++ b/stateful-functions-flink/stateful-functions-flink-launcher/src/main/java/com/ververica/statefun/flink/launcher/StatefulFunctionsJobGraphRetriever.java
@@ -18,9 +18,10 @@ package com.ververica.statefun.flink.launcher;
 
 import static java.util.Objects.requireNonNull;
 
-import com.ververica.statefun.flink.core.ModuleSpecs;
-import com.ververica.statefun.flink.core.ModuleSpecs.ModuleSpec;
 import com.ververica.statefun.flink.core.StatefulFunctionsJob;
+import com.ververica.statefun.flink.core.spi.Constants;
+import com.ververica.statefun.flink.core.spi.ModuleSpecs;
+import com.ververica.statefun.flink.core.spi.ModuleSpecs.ModuleSpec;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
@@ -72,10 +73,6 @@ final class StatefulFunctionsJobGraphRetriever implements JobGraphRetriever {
           classPath.add(uri.toURL());
         }
       }
-      LOG.info(
-          "Found {} additional module jars in {} modules",
-          classPath.size(),
-          specs.modules().size());
       return classPath;
     } catch (IOException e) {
       throw new RuntimeException(


### PR DESCRIPTION
This PR adds the initial support for describing a stateful function
module via module.yaml file. These files are auto-discovered by scanning
the module root directory.