### PR TITLE
Support any Protobuf Message in ProtoRouter

### DIFF
--- a/stateful-functions-flink/stateful-functions-flink-core/src/main/java/com/ververica/statefun/flink/core/jsonmodule/JsonModule.java
+++ b/stateful-functions-flink/stateful-functions-flink-core/src/main/java/com/ververica/statefun/flink/core/jsonmodule/JsonModule.java
@@ -20,7 +20,7 @@ import static java.lang.String.format;
 import static java.util.stream.Collectors.toMap;
 
 import com.google.protobuf.Descriptors;
-import com.google.protobuf.DynamicMessage;
+import com.google.protobuf.Message;
 import com.ververica.statefun.flink.core.common.ResourceLocator;
 import com.ververica.statefun.flink.core.jsonmodule.json.Pointers;
 import com.ververica.statefun.flink.core.jsonmodule.json.Selectors;
@@ -85,17 +85,17 @@ final class JsonModule implements StatefulFunctionModule {
       // dynamic.
       requireProtobufRouterType(router);
 
-      IngressIdentifier<DynamicMessage> id = targetRouterIngress(router);
+      IngressIdentifier<Message> id = targetRouterIngress(router);
       binder.bindIngressRouter(id, dynamicRouter(router));
     }
   }
 
   private void configureIngress(Binder binder, Iterable<? extends JsonNode> ingressNode) {
     for (JsonNode ingress : ingressNode) {
-      IngressIdentifier<DynamicMessage> id = ingressId(ingress);
+      IngressIdentifier<Message> id = ingressId(ingress);
       IngressType type = ingressType(ingress);
 
-      JsonIngressSpec<DynamicMessage> ingressSpec = new JsonIngressSpec<>(type, id, ingress);
+      JsonIngressSpec<Message> ingressSpec = new JsonIngressSpec<>(type, id, ingress);
       binder.bindIngress(ingressSpec);
     }
   }
@@ -110,17 +110,17 @@ final class JsonModule implements StatefulFunctionModule {
     return new IngressType(nn.namespace, nn.name);
   }
 
-  private static IngressIdentifier<DynamicMessage> ingressId(JsonNode ingress) {
+  private static IngressIdentifier<Message> ingressId(JsonNode ingress) {
     String ingressId = Selectors.textAt(ingress, Pointers.Ingress.META_ID);
     NamespaceNamePair nn = NamespaceNamePair.from(ingressId);
-    return new IngressIdentifier<>(DynamicMessage.class, nn.namespace, nn.name);
+    return new IngressIdentifier<>(Message.class, nn.namespace, nn.name);
   }
 
   // ----------------------------------------------------------------------------------------------------------
   // Routers
   // ----------------------------------------------------------------------------------------------------------
 
-  private static Router<DynamicMessage> dynamicRouter(JsonNode router) {
+  private static Router<Message> dynamicRouter(JsonNode router) {
     String addressTemplate = Selectors.textAt(router, Pointers.Routers.SPEC_TARGET);
     String descriptorSetPath = Selectors.textAt(router, Pointers.Routers.SPEC_DESCRIPTOR);
     String messageType = Selectors.textAt(router, Pointers.Routers.SPEC_MESSAGE_TYPE);
@@ -149,10 +149,10 @@ final class JsonModule implements StatefulFunctionModule {
     }
   }
 
-  private static IngressIdentifier<DynamicMessage> targetRouterIngress(JsonNode routerNode) {
+  private static IngressIdentifier<Message> targetRouterIngress(JsonNode routerNode) {
     String targetIngress = Selectors.textAt(routerNode, Pointers.Routers.SPEC_INGRESS);
     NamespaceNamePair nn = NamespaceNamePair.from(targetIngress);
-    return new IngressIdentifier<>(DynamicMessage.class, nn.namespace, nn.name);
+    return new IngressIdentifier<>(Message.class, nn.namespace, nn.name);
   }
 
   private static void requireProtobufRouterType(JsonNode routerNode) {

--- a/stateful-functions-flink/stateful-functions-flink-core/src/main/java/com/ververica/statefun/flink/core/protorouter/AddressResolver.java
+++ b/stateful-functions-flink/stateful-functions-flink-core/src/main/java/com/ververica/statefun/flink/core/protorouter/AddressResolver.java
@@ -16,7 +16,7 @@
 package com.ververica.statefun.flink.core.protorouter;
 
 import com.google.protobuf.Descriptors;
-import com.google.protobuf.DynamicMessage;
+import com.google.protobuf.Message;
 import com.ververica.statefun.flink.core.types.protobuf.protopath.ProtobufPath;
 import com.ververica.statefun.sdk.Address;
 import com.ververica.statefun.sdk.FunctionType;
@@ -89,7 +89,7 @@ final class AddressResolver {
     this.functionId = Objects.requireNonNull(functionId);
   }
 
-  Address evaluate(DynamicMessage message) {
+  Address evaluate(Message message) {
     FunctionType functionType =
         new FunctionType(functionNamespace.evaluate(message), functionName.evaluate(message));
 

--- a/stateful-functions-flink/stateful-functions-flink-core/src/main/java/com/ververica/statefun/flink/core/protorouter/ProtobufRouter.java
+++ b/stateful-functions-flink/stateful-functions-flink-core/src/main/java/com/ververica/statefun/flink/core/protorouter/ProtobufRouter.java
@@ -17,6 +17,7 @@ package com.ververica.statefun.flink.core.protorouter;
 
 import com.google.protobuf.Descriptors;
 import com.google.protobuf.DynamicMessage;
+import com.google.protobuf.Message;
 import com.ververica.statefun.flink.core.types.protobuf.protopath.ProtobufPath;
 import com.ververica.statefun.sdk.Address;
 import com.ververica.statefun.sdk.io.Router;
@@ -44,7 +45,7 @@ import java.util.Objects;
  * <p>This message would be routed to the address: {@code Address(FunctionType(com.ververica,
  * python-function), bob)}.
  */
-public final class ProtobufRouter implements Router<DynamicMessage> {
+public final class ProtobufRouter implements Router<Message> {
 
   public static ProtobufRouter forAddressTemplate(
       Descriptors.Descriptor descriptor, String addressTemplate) {
@@ -59,7 +60,7 @@ public final class ProtobufRouter implements Router<DynamicMessage> {
   }
 
   @Override
-  public void route(DynamicMessage message, Downstream<DynamicMessage> downstream) {
+  public void route(Message message, Downstream<Message> downstream) {
     Address targetAddress = addressResolver.evaluate(message);
     downstream.forward(targetAddress, message);
   }

--- a/stateful-functions-flink/stateful-functions-flink-core/src/main/java/com/ververica/statefun/flink/core/protorouter/TemplateEvaluator.java
+++ b/stateful-functions-flink/stateful-functions-flink-core/src/main/java/com/ververica/statefun/flink/core/protorouter/TemplateEvaluator.java
@@ -16,7 +16,7 @@
 package com.ververica.statefun.flink.core.protorouter;
 
 import com.google.protobuf.Descriptors;
-import com.google.protobuf.DynamicMessage;
+import com.google.protobuf.Message;
 import com.ververica.statefun.flink.core.types.protobuf.protopath.ProtobufPath;
 import java.util.List;
 import java.util.function.Function;
@@ -24,7 +24,7 @@ import java.util.function.Function;
 final class TemplateEvaluator {
 
   private interface FragmentEvaluator {
-    void eval(StringBuilder builder, DynamicMessage message);
+    void eval(StringBuilder builder, Message message);
   }
 
   private final FragmentEvaluator[] fragmentEvaluators;
@@ -35,7 +35,7 @@ final class TemplateEvaluator {
     this.fragmentEvaluators = fragmentEvaluators(descriptor, fragments);
   }
 
-  public String evaluate(DynamicMessage message) {
+  public String evaluate(Message message) {
     for (FragmentEvaluator e : fragmentEvaluators) {
       e.eval(builder, message);
     }
@@ -62,7 +62,7 @@ final class TemplateEvaluator {
 
   private static FragmentEvaluator dynamicEvaluator(
       Descriptors.Descriptor descriptor, TemplateParser.TextFragment fragment) {
-    final Function<DynamicMessage, ?> protopathEvaluator =
+    final Function<Message, ?> protopathEvaluator =
         ProtobufPath.protobufPath(descriptor, fragment.fragment());
     return (builder, message) -> {
       Object result = protopathEvaluator.apply(message);

--- a/stateful-functions-flink/stateful-functions-flink-core/src/main/java/com/ververica/statefun/flink/core/types/protobuf/protopath/PathFragmentDescriptor.java
+++ b/stateful-functions-flink/stateful-functions-flink-core/src/main/java/com/ververica/statefun/flink/core/types/protobuf/protopath/PathFragmentDescriptor.java
@@ -16,7 +16,7 @@
 package com.ververica.statefun.flink.core.types.protobuf.protopath;
 
 import com.google.protobuf.Descriptors;
-import com.google.protobuf.DynamicMessage;
+import com.google.protobuf.Message;
 import java.util.Objects;
 
 final class PathFragmentDescriptor {
@@ -28,7 +28,7 @@ final class PathFragmentDescriptor {
     this.pathFragment = Objects.requireNonNull(pathFragment);
   }
 
-  Object value(DynamicMessage message) {
+  Object value(Message message) {
     int index = pathFragment.getIndex();
     if (index >= 0) {
       return message.getRepeatedField(descriptor, index);

--- a/stateful-functions-flink/stateful-functions-flink-core/src/main/java/com/ververica/statefun/flink/core/types/protobuf/protopath/ProtobufDynamicMessageLens.java
+++ b/stateful-functions-flink/stateful-functions-flink-core/src/main/java/com/ververica/statefun/flink/core/types/protobuf/protopath/ProtobufDynamicMessageLens.java
@@ -15,11 +15,11 @@
  */
 package com.ververica.statefun.flink.core.types.protobuf.protopath;
 
-import com.google.protobuf.DynamicMessage;
+import com.google.protobuf.Message;
 import java.util.List;
 import java.util.function.Function;
 
-final class ProtobufDynamicMessageLens implements Function<DynamicMessage, Object> {
+final class ProtobufDynamicMessageLens implements Function<Message, Object> {
   private final PathFragmentDescriptor[] path;
   private final PathFragmentDescriptor value;
 
@@ -29,7 +29,7 @@ final class ProtobufDynamicMessageLens implements Function<DynamicMessage, Objec
   }
 
   @Override
-  public Object apply(DynamicMessage message) {
+  public Object apply(Message message) {
     message = traverseToTheLastMessage(message);
     return value.value(message);
   }
@@ -40,9 +40,9 @@ final class ProtobufDynamicMessageLens implements Function<DynamicMessage, Objec
    * last Message which contains the desired value. For example the path defined by: {@code .a.b.c}
    * would result with {@code b} returned.
    */
-  private DynamicMessage traverseToTheLastMessage(DynamicMessage root) {
+  private Message traverseToTheLastMessage(Message root) {
     for (PathFragmentDescriptor p : path) {
-      root = (DynamicMessage) p.value(root);
+      root = (Message) p.value(root);
     }
     return root;
   }

--- a/stateful-functions-flink/stateful-functions-flink-core/src/main/java/com/ververica/statefun/flink/core/types/protobuf/protopath/ProtobufPath.java
+++ b/stateful-functions-flink/stateful-functions-flink-core/src/main/java/com/ververica/statefun/flink/core/types/protobuf/protopath/ProtobufPath.java
@@ -16,7 +16,7 @@
 package com.ververica.statefun.flink.core.types.protobuf.protopath;
 
 import com.google.protobuf.Descriptors;
-import com.google.protobuf.DynamicMessage;
+import com.google.protobuf.Message;
 import java.util.List;
 import java.util.function.Function;
 
@@ -47,7 +47,7 @@ public final class ProtobufPath {
    * @param pathString an {@code ProtocolBuffer}'s path expression.
    * @return an ordered list of path fragments.
    */
-  public static Function<DynamicMessage, ?> protobufPath(
+  public static Function<Message, ?> protobufPath(
       Descriptors.Descriptor messageDescriptor, String pathString) {
     List<PathFragment> fields = ProtobufPathParser.parse(pathString);
     List<PathFragmentDescriptor> pathFragments =

--- a/stateful-functions-flink/stateful-functions-flink-core/src/test/java/com/ververica/statefun/flink/core/jsonmodule/JsonModuleTest.java
+++ b/stateful-functions-flink/stateful-functions-flink-core/src/test/java/com/ververica/statefun/flink/core/jsonmodule/JsonModuleTest.java
@@ -18,7 +18,7 @@ package com.ververica.statefun.flink.core.jsonmodule;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertThat;
 
-import com.google.protobuf.DynamicMessage;
+import com.google.protobuf.Message;
 import com.ververica.statefun.flink.core.StatefulFunctionsUniverse;
 import com.ververica.statefun.flink.core.message.MessageFactoryType;
 import com.ververica.statefun.sdk.FunctionType;
@@ -63,7 +63,7 @@ public class JsonModuleTest {
 
     assertThat(
         universe.routers(),
-        hasKey(new IngressIdentifier<>(DynamicMessage.class, "com.mycomp.igal", "names")));
+        hasKey(new IngressIdentifier<>(Message.class, "com.mycomp.igal", "names")));
   }
 
   private static StatefulFunctionModule fromPath(String path) {

--- a/stateful-functions-flink/stateful-functions-flink-core/src/test/java/com/ververica/statefun/flink/core/types/protobuf/protopath/ProtobufPathTest.java
+++ b/stateful-functions-flink/stateful-functions-flink-core/src/test/java/com/ververica/statefun/flink/core/types/protobuf/protopath/ProtobufPathTest.java
@@ -21,8 +21,6 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
 import com.google.protobuf.Any;
-import com.google.protobuf.DynamicMessage;
-import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.Message;
 import com.ververica.statefun.flink.core.types.protobuf.generated.TestProtos;
 import com.ververica.statefun.flink.core.types.protobuf.generated.TestProtos.NestedMessage;
@@ -34,55 +32,45 @@ public class ProtobufPathTest {
 
   @Test
   public void exampleUsage() {
-    Message originalMessage = SimpleMessage.newBuilder().setName("bob").build();
-    DynamicMessage message = dynamic(originalMessage);
+    Message message = SimpleMessage.newBuilder().setName("bob").build();
 
-    Function<DynamicMessage, ?> getter =
-        protobufPath(originalMessage.getDescriptorForType(), "$.name");
+    Function<Message, ?> getter = protobufPath(message.getDescriptorForType(), "$.name");
 
     assertThat(getter.apply(message), is("bob"));
   }
 
   @Test
   public void repeatedMessage() {
-    Message originalMessage =
+    Message message =
         TestProtos.RepeatedMessage.newBuilder()
             .addSimpleMessage(SimpleMessage.newBuilder().setName("bruce").build())
             .addSimpleMessage(SimpleMessage.newBuilder().setName("lee").build())
             .build();
 
-    DynamicMessage message = dynamic(originalMessage);
-
-    Function<DynamicMessage, ?> getter =
-        protobufPath(originalMessage.getDescriptorForType(), "$.simple_message[1].name");
+    Function<Message, ?> getter =
+        protobufPath(message.getDescriptorForType(), "$.simple_message[1].name");
 
     assertThat(getter.apply(message), is("lee"));
   }
 
   @Test
   public void nestedMessage() {
-    Message originalMessage =
+    Message message =
         NestedMessage.newBuilder()
             .setFoo(NestedMessage.Foo.newBuilder().setName("lee").build())
             .build();
 
-    DynamicMessage message = dynamic(originalMessage);
-
-    Function<DynamicMessage, ?> getter =
-        protobufPath(originalMessage.getDescriptorForType(), "$.foo.name");
+    Function<Message, ?> getter = protobufPath(message.getDescriptorForType(), "$.foo.name");
 
     assertThat(getter.apply(message), is("lee"));
   }
 
   @Test
   public void messageWithEnum() {
-    TestProtos.MessageWithEnum originalMessage =
+    TestProtos.MessageWithEnum message =
         TestProtos.MessageWithEnum.newBuilder().setLetter(TestProtos.Letter.B).build();
 
-    DynamicMessage message = dynamic(originalMessage);
-
-    Function<DynamicMessage, ?> getter =
-        protobufPath(originalMessage.getDescriptorForType(), "$.letter");
+    Function<Message, ?> getter = protobufPath(message.getDescriptorForType(), "$.letter");
 
     Object apply = getter.apply(message);
     assertThat(apply, is(TestProtos.Letter.B.getValueDescriptor()));
@@ -90,33 +78,20 @@ public class ProtobufPathTest {
 
   @Test
   public void importedMessage() {
-    Message originalMessage =
+    Message message =
         TestProtos.ImportedMessage.newBuilder().setImported(Any.getDefaultInstance()).build();
-    DynamicMessage message = dynamic(originalMessage);
 
-    Function<DynamicMessage, ?> getter =
-        protobufPath(originalMessage.getDescriptorForType(), "$.imported");
+    Function<Message, ?> getter = protobufPath(message.getDescriptorForType(), "$.imported");
 
     assertThat(getter.apply(message), is(Any.getDefaultInstance()));
   }
 
   @Test
   public void oneOfMessage() {
-    Message originalMessage = TestProtos.OneOfMessage.newBuilder().setBar(1234).build();
+    Message message = TestProtos.OneOfMessage.newBuilder().setBar(1234).build();
 
-    DynamicMessage message = dynamic(originalMessage);
-
-    Function<DynamicMessage, ?> getter =
-        protobufPath(originalMessage.getDescriptorForType(), "$.bar");
+    Function<Message, ?> getter = protobufPath(message.getDescriptorForType(), "$.bar");
 
     assertThat(getter.apply(message), is(1234L));
-  }
-
-  private static DynamicMessage dynamic(Message message) {
-    try {
-      return DynamicMessage.parseFrom(message.getDescriptorForType(), message.toByteString());
-    } catch (InvalidProtocolBufferException e) {
-      throw new AssertionError(e);
-    }
   }
 }


### PR DESCRIPTION
This PR allows routers defined in a `module.yaml` to be attached to any existing ingresses that produce a Protobuf type (instead of only instances of a `DynamicMessage`)