### PR TITLE
Removing unnecessary build() from nested proto messages

### DIFF
--- a/stateful-functions-examples/stateful-functions-ridesharing-example/stateful-functions-ridesharing-example-simulator/src/main/java/com/ververica/statefun/examples/ridesharing/simulator/simulation/Driver.java
+++ b/stateful-functions-examples/stateful-functions-ridesharing-example/stateful-functions-ridesharing-example-simulator/src/main/java/com/ververica/statefun/examples/ridesharing/simulator/simulation/Driver.java
@@ -75,9 +75,7 @@ public class Driver implements Simulatee {
         InboundDriverMessage.newBuilder()
             .setDriverId(driverId)
             .setLocationUpdate(
-                InboundDriverMessage.LocationUpdate.newBuilder()
-                    .setCurrentGeoCell(currentLocation)
-                    .build())
+                InboundDriverMessage.LocationUpdate.newBuilder().setCurrentGeoCell(currentLocation))
             .build());
 
     // notify the websocket
@@ -173,9 +171,7 @@ public class Driver implements Simulatee {
         InboundDriverMessage.newBuilder()
             .setDriverId(driverId)
             .setLocationUpdate(
-                InboundDriverMessage.LocationUpdate.newBuilder()
-                    .setCurrentGeoCell(currentLocation)
-                    .build())
+                InboundDriverMessage.LocationUpdate.newBuilder().setCurrentGeoCell(currentLocation))
             .build());
 
     // notify the websocket
@@ -213,8 +209,7 @@ public class Driver implements Simulatee {
               .setDriverId(driverId)
               .setRideEnded(
                   InboundDriverMessage.RideEnded.newBuilder()
-                      .setRideId(rideInformation.getPassengerId())
-                      .build())
+                      .setRideId(rideInformation.getPassengerId()))
               .build());
 
       rideInformation = null;
@@ -257,9 +252,7 @@ public class Driver implements Simulatee {
         InboundDriverMessage.newBuilder()
             .setDriverId(driverId)
             .setLocationUpdate(
-                InboundDriverMessage.LocationUpdate.newBuilder()
-                    .setCurrentGeoCell(currentLocation)
-                    .build())
+                InboundDriverMessage.LocationUpdate.newBuilder().setCurrentGeoCell(currentLocation))
             .build());
 
     // notify the websocket

--- a/stateful-functions-examples/stateful-functions-ridesharing-example/stateful-functions-ridesharing-example-simulator/src/main/java/com/ververica/statefun/examples/ridesharing/simulator/simulation/Passenger.java
+++ b/stateful-functions-examples/stateful-functions-ridesharing-example/stateful-functions-ridesharing-example-simulator/src/main/java/com/ververica/statefun/examples/ridesharing/simulator/simulation/Passenger.java
@@ -55,8 +55,7 @@ public class Passenger implements Simulatee {
             .setRequestRide(
                 InboundPassengerMessage.RequestRide.newBuilder()
                     .setStartGeoCell(startCell)
-                    .setEndGeoCell(endCell)
-                    .build())
+                    .setEndGeoCell(endCell))
             .build();
 
     // send to application

--- a/stateful-functions-flink/stateful-functions-flink-common/src/test/java/com/ververica/statefun/flink/common/protopath/ProtobufPathTest.java
+++ b/stateful-functions-flink/stateful-functions-flink-common/src/test/java/com/ververica/statefun/flink/common/protopath/ProtobufPathTest.java
@@ -43,8 +43,8 @@ public class ProtobufPathTest {
   public void repeatedMessage() {
     Message message =
         TestProtos.RepeatedMessage.newBuilder()
-            .addSimpleMessage(SimpleMessage.newBuilder().setName("bruce").build())
-            .addSimpleMessage(SimpleMessage.newBuilder().setName("lee").build())
+            .addSimpleMessage(SimpleMessage.newBuilder().setName("bruce"))
+            .addSimpleMessage(SimpleMessage.newBuilder().setName("lee"))
             .build();
 
     Function<Message, ?> getter =
@@ -56,9 +56,7 @@ public class ProtobufPathTest {
   @Test
   public void nestedMessage() {
     Message message =
-        NestedMessage.newBuilder()
-            .setFoo(NestedMessage.Foo.newBuilder().setName("lee").build())
-            .build();
+        NestedMessage.newBuilder().setFoo(NestedMessage.Foo.newBuilder().setName("lee")).build();
 
     Function<Message, ?> getter = protobufPath(message.getDescriptorForType(), "$.foo.name");
 


### PR DESCRIPTION
When setting a nested proto message, you can set the message builder objects instead of the actual message.